### PR TITLE
Adding Overriding API Url's Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ need a Nexmo account. Sign up [for free at nexmo.com][signup].
 * [Number Insight API](#number-insight-api)
 * [Managing Secrets](#managing-secrets)
 * [Application API](#application-api)
+* [Overriding API url's](#overriding-api-url's)
 * [License](#license)
 
 
@@ -360,6 +361,33 @@ specify a different token identifier:
 client.auth(nbf=nbf, exp=exp, jti=jti)
 ```
 
+## Overriding API url's
+
+By default, our API url's are hardcoded. For use cases where these url's are not accessible, best practices to override these url's are the following:
+
+- Setting new API url's when creating an instance of the client:
+
+```python
+import nexmo
+client = nexmo.Client()
+client.host = 'new.host.url'
+client.api_host = 'new.api.host'
+```
+- Creating a new class that extends from client class and overrides these values in the constructor:
+
+```python
+import nexmo
+class MyClient(nexmo.Client):
+    def __init__(self):
+        super().__init__()
+        self.host = 'new.hosts.url'
+        self.api_host = 'new.api.hosts'
+
+#Usage
+client = MyClient()
+```
+
+
 Contributing
 ------------
 
@@ -376,7 +404,6 @@ The tests are all written with pytest. You run them with:
 ```bash
 make test
 ```
-
 
 License
 -------


### PR DESCRIPTION
Adding simple instructions for users who otherwise may not have access to default API url's